### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/django/first-steps-with-django.rst
+++ b/docs/django/first-steps-with-django.rst
@@ -201,7 +201,7 @@ To use this with your project you need to follow these steps:
 
     .. code-block:: python
 
-        CELERY_RESULT_BACKEND = 'django-cache'
+        CELERY_CACHE_BACKEND = 'django-cache'
 
     We can also use the cache defined in the CACHES setting in django.
 


### PR DESCRIPTION
## Description
`CELERY_CACHE_BACKEND` is the right property for cache backend, not `CELERY_RESULT_BACKEND`